### PR TITLE
Fix Homepage Events

### DIFF
--- a/src/app/events/detail/[eventName]/page.tsx
+++ b/src/app/events/detail/[eventName]/page.tsx
@@ -4,6 +4,7 @@ import EventDetailPage from "@/components/event-detail/EventDetailPage";
 import GlobalLayout from "@/components/GlobalLayout";
 import Head from "next/head";
 import { Metadata } from "next";
+import useCurrentEventsSorted from "@/hooks/useCurrentEventsSorted";
 
 type EventDetailPageProps = {
   params: {
@@ -79,12 +80,16 @@ export default function EventsDetailPage ({params: {eventName}}:EventDetailPageP
 };
 
 export async function generateStaticParams() {
-  const events = eventsData.events.filter((event)=> {
-    const currentDate = new Date();
-      // Convert the string date to a Date object
-      const eventDate = new Date(event.firstDayOfEvent);
-      // Compare the event date with the current date
-      return eventDate >= currentDate;
+  const currentDate = new Date();
+  const events = eventsData.events
+  .filter(event => {
+    const eventDate = new Date(event.firstDayOfEvent);
+    return (!event.postponed && eventDate >= currentDate) || event.postponed;
+  })
+  .sort((a, b) => {
+    const timestampA = new Date(a.firstDayOfEvent).getTime();
+    const timestampB = new Date(b.firstDayOfEvent).getTime();
+    return timestampA - timestampB;
   });
 
    return events.map(event => ({

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -82,7 +82,7 @@ export default function Navbar(){
                         alt="Givher Logo"
                         width={210}
                         height={92}
-                        className="dark:hidden max-w-[105px]"
+                        className="dark:hidden max-w-[105px] image-rendering-crisp-edges"
                         loading="eager"
                         />
                     <img
@@ -90,7 +90,7 @@ export default function Navbar(){
                         alt="Givher Logo"
                         width={210}
                         height={92}
-                        className="hidden dark:block max-w-[105px]"
+                        className="hidden dark:block max-w-[105px] image-rendering-crisp-edges"
                         loading="eager"
                         />
                     </Link>    
@@ -111,7 +111,7 @@ export default function Navbar(){
                         onChange={() => {
                         setDarkMode(!darkMode);
                         }}
-                        className="h-[0px] w-[0px]"
+                        className="h-[0px] w-[0px] appearance-none"
                     />
                     <span
                         id="slider round"
@@ -120,8 +120,8 @@ export default function Navbar(){
                             ? 'bg-softOpal before:bg-mauvelous before:translate-x-[26px]'
                             : 'bg-grey before:bg-softOpal'
                         }`}
-                    ></span>
-                    
+                    >
+                    </span>
                     </label>
                     <p className="text-black dark:text-mauvelous">Dark Mode</p>
                 </div>

--- a/src/components/event-detail/UpcomingClientEvents.tsx
+++ b/src/components/event-detail/UpcomingClientEvents.tsx
@@ -2,23 +2,18 @@ import React from "react";
 import EventCard from "../common/EventCard";
 import { EventType } from "@/types/types";
 import eventsData from "../../data/events.json";
+import useCurrentEventsSorted from "@/hooks/useCurrentEventsSorted";
 
 export default function UpcomingClientEvents({events, clientName}:{events: EventType[], clientName:string}){
-    const currentDate = new Date();
-    const shownEvents = events.filter(event => {
-        // Convert the string date to a Date object
-        const eventDate = new Date(event.firstDayOfEvent);
-        // Compare the event date with the current date
-        return eventDate >= currentDate;
-    }).slice(0, 3);
-    
+    const currentEvents = useCurrentEventsSorted();
+
     return (
         <div className="bg-softOpal dark:bg-navySmoke py-[2.5rem] flex justify-center">
             <div className="flex flex-col w-full gap-[2.5rem] max-w-[85.75rem] mx-[0.625rem] lg:mx-[1.5625rem]">
                 <h1 className="font-ramenson text-navySmoke dark:text-softOpal text-center lg:text-left">{eventsData.clientEventPageUpcomingEventsTitle}</h1>
                 <h2 className="uppercase text-black dark:text-softOpal text-[1rem] text-center lg:text-left">{clientName}</h2>
                 <div className={`flex flex-col lg:flex-row ${events.length < 3 ? "":"lg:justify-between"} gap-[2rem] items-center w-full`}>
-                    {shownEvents.map((e, i)=>(
+                    {currentEvents.map((e, i)=>(
                         <EventCard key={`${i}-${e.clientName}-${e.eventName}-${e.firstDayOfEvent}`} event={e} type="detail-page"/>
                     ))}
                 </div>

--- a/src/components/events/EventsPage.tsx
+++ b/src/components/events/EventsPage.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from "react";
 import FeaturedEvents from "./FeaturedEvents";
 import eventsData from "../../data/events.json";
 import ComingSoon from "./ComingSoon";
+import useCurrentEventsSorted from "@/hooks/useCurrentEventsSorted";
 
 import { lazy } from 'react';
 
@@ -10,50 +11,37 @@ const AllEvents = lazy(() => import('./AllEvents'));
 
 
 export default function EventsPage(){
+  const currentEvents = useCurrentEventsSorted();
 
-    const shownEvents = eventsData.events
-    .filter(event => {
-      const currentDate = new Date();
-      const eventDate = new Date(event.firstDayOfEvent);
-      // Include events that are occurring today or in the future
-      // Include postponed events regardless of whether they are in the past or future
-      return (!event.postponed && eventDate >= currentDate) || (event.postponed);
-    })
-    .sort((a, b) => {
-      const timestampA = new Date(a.firstDayOfEvent).getTime();
-      const timestampB = new Date(b.firstDayOfEvent).getTime();
-      return timestampA - timestampB;
-    });
-
-    //Pulls 4 events from list of events and coming soon events
-    const featuredEvents = useMemo(() => {
-        const comingSoonEvents = eventsData.comingSoon;
-        const firstFiveEvents = eventsData.events.slice(0, 4);
-      
-        if (firstFiveEvents.length < 4 && comingSoonEvents) {
-          const remainingEventsCount = 4 - firstFiveEvents.length;
-          const additionalComingSoonEvents = comingSoonEvents.slice(0, remainingEventsCount);
-          return [...firstFiveEvents, ...additionalComingSoonEvents].sort((a, b) => {
-            const timestampA = new Date(a.firstDayOfEvent).getTime();
-            const timestampB = new Date(b.firstDayOfEvent).getTime();
-            return timestampA - timestampB;
-          });
-        }
-      
-        return firstFiveEvents.sort((a, b) => {
+  //Pulls 4 events from list of events and coming soon events
+  const featuredEvents = useMemo(() => {
+      const comingSoonEvents = eventsData.comingSoon;
+      const firstFiveEvents = currentEvents.slice(0, 4);
+    
+      if (firstFiveEvents.length < 4 && comingSoonEvents) {
+        const remainingEventsCount = 4 - firstFiveEvents.length;
+        const additionalComingSoonEvents = comingSoonEvents.slice(0, remainingEventsCount);
+        return [...firstFiveEvents, ...additionalComingSoonEvents].sort((a, b) => {
           const timestampA = new Date(a.firstDayOfEvent).getTime();
           const timestampB = new Date(b.firstDayOfEvent).getTime();
           return timestampA - timestampB;
         });
-      }, []);
-      
-    return (
-        <div className="min-h-[calc(100vh-360px)] bg-softOpal dark:bg-navySmoke">
-            <FeaturedEvents events={featuredEvents}/>
-            <AllEvents events={shownEvents}/>
-            {!!eventsData.comingSoon.length && (
-                <ComingSoon comingEvents={eventsData.comingSoon}/>
-            )}
-        </div>
-    )
+      }
+    
+      return firstFiveEvents.sort((a, b) => {
+        const timestampA = new Date(a.firstDayOfEvent).getTime();
+        const timestampB = new Date(b.firstDayOfEvent).getTime();
+        return timestampA - timestampB;
+      });
+    }, [currentEvents]);
+    
+  return (
+      <div className="min-h-[calc(100vh-360px)] bg-softOpal dark:bg-navySmoke">
+          <FeaturedEvents events={featuredEvents}/>
+          <AllEvents events={currentEvents}/>
+          {!!eventsData.comingSoon.length && (
+              <ComingSoon comingEvents={eventsData.comingSoon}/>
+          )}
+      </div>
+  )
 }

--- a/src/components/home/HomepageV2.tsx
+++ b/src/components/home/HomepageV2.tsx
@@ -1,32 +1,24 @@
 import React from "react";
 
 import homepageData from "../../data/homepage.json";
-import eventsData from "../../data/events.json";
 import { lazy } from 'react';
 
 import HeroVideo from "./HeroVideo";
 import FloatingLogos from "./FloatingLogos";
 import UpcomingEvents from "./UpcomingEvents";
 import AboutUs from "./AboutUs";
+
+import useCurrentEventsSorted from "@/hooks/useCurrentEventsSorted";
+
 const Services = lazy(() => import('./Services'));
 const EventsCarousel = lazy(() => import('./EventsCarousel'));
 const Form = lazy(() => import('./Form'));
 
 export default function Homepage(){
     const {video, logos, services, featuredEvents, about, eventCarousel, form} = homepageData;
-    const { events } = eventsData;
+    const currentEvents = useCurrentEventsSorted();
 
-    const currentDate = new Date().getTime();
-    const upcomingEvents = events.sort((a, b) => {
-        const dateA = new Date(a.firstDayOfEvent).getTime();
-        const dateB = new Date(b.firstDayOfEvent).getTime();
-        // Exclude past events during sorting
-        return dateA >= currentDate ? (dateB >= currentDate ? dateA - dateB : -1) : 1;
-    }).filter(event => {
-        const eventDate = new Date(event.firstDayOfEvent).getTime();
-        // Exclude events happening on the current day
-        return eventDate > currentDate;
-    }).slice(0, 3);
+    const upcomingEvents = currentEvents.slice(0, 3);
 
     return (
         <>

--- a/src/hooks/useCurrentEventsSorted.ts
+++ b/src/hooks/useCurrentEventsSorted.ts
@@ -1,0 +1,23 @@
+import { useMemo } from "react";
+import eventsData from "../data/events.json";
+
+const useCurrentEventsSorted = () => {
+  const currentEvents = useMemo(() => {
+    const currentDate = new Date();
+    
+    return eventsData.events
+      .filter(event => {
+        const eventDate = new Date(event.firstDayOfEvent);
+        return (!event.postponed && eventDate >= currentDate) || event.postponed;
+      })
+      .sort((a, b) => {
+        const timestampA = new Date(a.firstDayOfEvent).getTime();
+        const timestampB = new Date(b.firstDayOfEvent).getTime();
+        return timestampA - timestampB;
+      });
+  }, []);
+
+  return currentEvents;
+};
+
+export default useCurrentEventsSorted;


### PR DESCRIPTION
There was a bug that was showing past events on the homepage and generating event pages for them. This fix creates a hook to filter out past events and sort the in the correct order.

Additionally, I fixed a checkbox appearing behind the dark mode filter toggle in safari.