### PR TITLE
Bug: Homepage Still Showing Past Events

### DIFF
--- a/src/components/home/HomepageV2.tsx
+++ b/src/components/home/HomepageV2.tsx
@@ -1,3 +1,4 @@
+'use client'
 import React from "react";
 
 import homepageData from "../../data/homepage.json";


### PR DESCRIPTION
This issue may be due to server-side rendering the homepage. Trying to see if client-side rendering will eliminate the issue.