### PR TITLE
Updates for Past Clients + Past Events Fixes

### DIFF
--- a/content/all-events/the-30th-anniversary-90s-pac-party.md
+++ b/content/all-events/the-30th-anniversary-90s-pac-party.md
@@ -8,7 +8,7 @@ eventType: PAC
 eventCity: Sacramento
 eventState: CA
 eventLocation: The Mix Downtown
-clientName: California Primary Care Association
+clientName: CPCA Advocates
 eventButtonTextOne: Ticket & Sponsorship Information
 eventButtonLinkOne: https://events.givher.com/cpca-pac-30th-anniversary
 eventDescription:

--- a/lib/getAllClients.ts
+++ b/lib/getAllClients.ts
@@ -33,6 +33,7 @@ export default async function getAllClients(): Promise<Client[]> {
         clientWebsite: data.clientWebsite,
         clientW9Src: data.clientW9Src,
         hideClient: data.hideClient,
+        pastClient: data.pastClient,
         eventLink, // Add the computed eventLink field
       };
     })

--- a/src/app/(public)/events/detail/[eventSlugOrName]/page.tsx
+++ b/src/app/(public)/events/detail/[eventSlugOrName]/page.tsx
@@ -1,4 +1,4 @@
-export const revalidate = 86400;
+export const revalidate = 43200;
 
 import React from 'react';
 import EventDetailPage from '@/components/event-detail/EventDetailPage';

--- a/src/app/(public)/events/page.tsx
+++ b/src/app/(public)/events/page.tsx
@@ -1,4 +1,4 @@
-export const revalidate = 86400;
+export const revalidate = 3600;
 
 import React from 'react';
 import EventsPage from '@/components/events/EventsPage';

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,4 +1,4 @@
-export const revalidate = 86400;
+export const revalidate = 3600;
 
 import React from 'react';
 import Homepage from '@/components/home/HomepageV2';

--- a/src/app/(public)/past-events/page.tsx
+++ b/src/app/(public)/past-events/page.tsx
@@ -1,4 +1,4 @@
-export const revalidate = 86400;
+export const revalidate = 3600;
 
 import React from 'react';
 import PastEventsPage from '@/components/past-events/PastEventsPage';

--- a/src/components/clients/ClientCard.tsx
+++ b/src/components/clients/ClientCard.tsx
@@ -9,47 +9,71 @@ type ClientCardProps = {
 };
 
 export default function ClientCard({ clientInfo }: ClientCardProps) {
-  const { clientName, clientLogo, clientWebsite, clientW9Src, eventLink } =
-    clientInfo;
+  const {
+    clientName,
+    clientLogo,
+    clientWebsite,
+    clientW9Src,
+    eventLink,
+    pastClient,
+  } = clientInfo;
   return (
-    <div className="group">
-      <div className="relative bg-white rounded-[20px] border border-1 border-mauvelous flex items-center justify-center w-[280px] h-[175px]">
+    <div className="group relative">
+      {!!pastClient && (
+        <div className="bg-electricYellow text-navySmoke font-visbyBold shadow-custom-shadow-small text-[12px] px-3 py-1 w-fit rounded-2xl absolute right-[-3px] top-[-13px] z-20">
+          Past Client
+        </div>
+      )}
+      <div className="relative bg-white rounded-xl shadow-custom-shadow-clients dark:shadow-custom-shadow-darkmode flex items-center justify-center w-[280px] h-[175px]">
         <Image
           priority={true}
           src={clientLogo}
           alt={`${clientName} logo`}
           width={280}
           height={175}
-          className="rounded-[20px] max-w-[250px] w-auto max-h-[150px] h-auto"
+          className="rounded-xl max-w-[250px] w-auto max-h-[150px] h-auto"
         />
-        <div className="absolute top-0 rounded-[20px] hidden group-hover:flex bg-opacity-80 bg-navySmoke h-full w-full px-[1rem] py-[1.5rem] flex-col justify-between">
+        <div className="absolute top-0 rounded-xl hidden group-hover:flex bg-opacity-80 bg-navySmoke h-full w-full px-[1rem] py-[1.5rem] flex-col justify-between">
           <p className="text-softOpal">{clientName}</p>
           <div className="flex justify-between">
-            {clientWebsite && (
+            {pastClient ? (
               <Link
                 className={`bg-electricYellow p-[0.75rem] min-w-[120px] rounded-[.5rem] font-medium text-black text-center`}
-                href={clientWebsite}
+                href={`/past-events?client=${encodeURIComponent(clientName)}`}
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Website
+                View Past Events
               </Link>
-            )}
-            {clientW9Src && (
-              <Link
-                className={`bg-softOpal p-[0.75rem] min-w-[120px] rounded-[.5rem] font-medium text-black text-center`}
-                href={clientW9Src}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                W-9
-              </Link>
+            ) : (
+              <>
+                {clientWebsite && (
+                  <Link
+                    className={`bg-electricYellow p-[0.75rem] min-w-[120px] rounded-[.5rem] font-medium text-black text-center`}
+                    href={clientWebsite}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Website
+                  </Link>
+                )}
+                {clientW9Src && (
+                  <Link
+                    className={`bg-softOpal p-[0.75rem] min-w-[120px] rounded-[.5rem] font-medium text-black text-center`}
+                    href={clientW9Src}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    W-9
+                  </Link>
+                )}
+              </>
             )}
           </div>
         </div>
       </div>
       <div className="px-[1rem] opacity-0 group-hover:opacity-100 pt-[0.5rem] text-visbyBold">
-        {eventLink && (
+        {eventLink && !pastClient && (
           <ArrowLink
             text={`View ${eventLink} Events`}
             color={'black'}

--- a/src/components/past-events/PastEventsHeader.tsx
+++ b/src/components/past-events/PastEventsHeader.tsx
@@ -93,16 +93,17 @@ export default function PastEventsHeader({
                 data-id={i}
                 className="past-carousel-cell h-[400px] xs:h-[425px] sm:h-[225px] mr-[2rem] m-[2rem]"
               >
-                <div className="group cursor-pointer flex flex-col justify-between sm:flex-row rounded-xl overflow-hidden  w-[270px] xs:w-[325px] sm:w-[625px] border border-navySmoke dark:border-softOpal shadow-custom-shadow">
+                <div className="group cursor-pointer flex flex-col justify-between sm:flex-row rounded-xl overflow-hidden h-[222px] w-[270px] xs:w-[325px] sm:w-[625px] border border-navySmoke dark:border-softOpal shadow-custom-shadow">
                   {e.detailImage && (
-                    <Image
-                      src={e.detailImage}
-                      alt={e.eventName}
-                      height={300}
-                      width={473}
-                      priority={priority}
-                      className="flickity-lazyloaded object-cover w-full max-w-[350px] max-h-[222px] rounded-s-xl"
-                    />
+                    <div className="relative w-full h-[222px] max-w-[350px]">
+                      <Image
+                        src={e.detailImage}
+                        alt={e.eventName}
+                        fill
+                        priority={priority}
+                        className="object-cover object-right rounded-s-xl"
+                      />
+                    </div>
                   )}
                   <div className="w-full sm:w-[275px] flex flex-col justify-between gap-[1.5rem] py-[1rem] pl-[1rem] border-navySmoke">
                     <div className="flex justify-between items-center gap-[1rem]">

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -132,6 +132,7 @@ export type Client = {
   clientW9Src: string;
   hideClient: boolean;
   eventLink: string;
+  pastClient: boolean;
 };
 
 export interface ClientImage {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -40,6 +40,8 @@ const config: Config = {
       },
       boxShadow: {
         'custom-shadow': '0 4px 20px 0 rgba(0,0,0,0.15)',
+        'custom-shadow-small': '0px 1px 4px rgba(0, 0, 0, 0.16)',
+        'custom-shadow-clients': '0px 3px 8px rgba(0, 0, 0, 0.24)',
         'custom-shadow-darkmode': '0 4px 20px 0 rgba(248,249,238,0.15)',
       },
       screens: {


### PR DESCRIPTION
Past Clients
- Badge for 'Past Client'
- Will show 'View Past Events' button instead of website/w-9

Past Events
- Fix images not correctly stretching in featured section
- Fix name of CPCA Advocates on past-event (so it can correctly look up the client's image)