### PR TITLE
add handling for event card images in svg format

### DIFF
--- a/src/components/common/EventCard.tsx
+++ b/src/components/common/EventCard.tsx
@@ -20,13 +20,21 @@ export default function EventCard({
       <div className="flex flex-col justify-between h-full gap-[1rem]">
         <div className="flex justify-between">
           <div className="max-w-[50%] h-[100px] flex items-center dark:bg-softOpal p-[0.5rem] rounded-md">
-            <Image
-              src={clientLogo}
-              width={280}
-              height={175}
-              className="w-auto max-h-[80px]"
-              alt={`${event.clientName} logo`}
-            />
+            {clientLogo.endsWith('.svg') ? (
+              <img
+                src={clientLogo}
+                alt={`${event.clientName} logo`}
+                className="w-auto max-h-[80px] h-[80px]"
+              />
+            ) : (
+              <Image
+                src={clientLogo}
+                width={280}
+                height={175}
+                alt={`${event.clientName} logo`}
+                className="w-auto max-h-[80px]"
+              />
+            )}
           </div>
           {event.eventType && (
             <div className="font-visbyBold text-[0.85rem] px-[1rem] py-[0.5rem] text-navySmoke bg-electricYellow border border-navySmoke border-r-0 h-min rounded-l-3xl">


### PR DESCRIPTION
I noticed on the event's page that the Victory Fund logo wasn't showing up on the event card. This is because the Image component from Next.js isn't setup to support svg files and there isn't a fixed height set up on the image to keep it responsive. So I add handling to detect if the file is an svg and apply a plain img tag with a fixed height. 